### PR TITLE
fix: ajax request

### DIFF
--- a/webapp/controller/View1.controller.js
+++ b/webapp/controller/View1.controller.js
@@ -9,13 +9,23 @@ sap.ui.define([
 
         return Controller.extend("reqres.controller.View1", {
             onInit: function () {
+
+                let myPathWithoutFile
+                if (window.location.href.indexOf("localhost") == -1) {
+                    const myPath = window.location.pathname
+                    myPathWithoutFile = myPath.substring(0, myPath.lastIndexOf('/'))
+                    console.log(myPathWithoutFile)
+                } else {
+                    myPathWithoutFile = ""
+                }
+
                 var that = this;
                 var oEntry = {};
                 // GET
                 var aData = jQuery.ajax({
                     type: "GET",
                     contentType: "application/json",
-                    url: "/api/users?page=2",
+                    url: myPathWithoutFile + "/api/users?page=2",
                     dataType: "json",
                     async: false,
                     success: function (data, textStatus, jqXHR) {


### PR DESCRIPTION
Hi @kevindass,
I fixed the ajax request so that it includes the application id when running in the Fiori Launchpad. I build the project and deployed it to CF - it all works fine now:

![Screenshot 2022-12-01 at 10 54 39](https://user-images.githubusercontent.com/65965098/205022585-2877892b-11be-4f3c-8e80-781fb660eb91.png)

I had some issues with the `npm install`, so you might also want to delete the `package-lock.json` and run a fresh install.

Please let me know in case you have questions.

Best, Nico
